### PR TITLE
Minor Registration API Update

### DIFF
--- a/registration/webserver.py
+++ b/registration/webserver.py
@@ -108,7 +108,10 @@ class WebserverCog(nextcord.ext.commands.Cog):
         user = self.bot.get_user(discord_id)
 
         try:
-            get_player_from_steam(steam_id)
+            player = get_player_from_steam(steam_id)
+            if player["discord"] == str(discord_id):
+                return (f"Your Steam and Discord accounts are already linked to each other. If this is an error, "
+                        f"please contact PugBot devs {DEV_DISCORD_LINK}")
             return f"Steam profile is already linked. Please contact PugBot devs {DEV_DISCORD_LINK}"
         except LookupError:
             # pass is not a mistake or incomplete implementation, this means the steam is unique and we can proceed

--- a/registration/webserver.py
+++ b/registration/webserver.py
@@ -110,8 +110,10 @@ class WebserverCog(nextcord.ext.commands.Cog):
         try:
             player = get_player_from_steam(steam_id)
             if player["discord"] == str(discord_id):
-                return (f"Your Steam and Discord accounts are already linked to each other. If this is an error, "
-                        f"please contact PugBot devs {DEV_DISCORD_LINK}")
+                return (
+                    f"Your Steam and Discord accounts are already linked to each other. If this is an error, "
+                    f"please contact PugBot devs {DEV_DISCORD_LINK}"
+                )
             return f"Steam profile is already linked. Please contact PugBot devs {DEV_DISCORD_LINK}"
         except LookupError:
             # pass is not a mistake or incomplete implementation, this means the steam is unique and we can proceed


### PR DESCRIPTION
Added a check and message when a user tries to register a Steam and Discord that are linked to each other already. Previously, users would have been notified that their Steam account was already linked with no indication that it was linked to the Discord account they authorized.